### PR TITLE
Adjust z-index of table loading bar

### DIFF
--- a/src/components/TableLite.vue
+++ b/src/components/TableLite.vue
@@ -948,7 +948,7 @@ export default defineComponent({
 
 .vtl-loading-mask {
   position: absolute;
-  z-index: 9998;
+  z-index: 1003;
   top: 0;
   left: 0;
   width: 100%;

--- a/src/components/TableLiteTs.vue
+++ b/src/components/TableLiteTs.vue
@@ -992,7 +992,7 @@ export default defineComponent({
 
 .vtl-loading-mask {
   position: absolute;
-  z-index: 9998;
+  z-index: 1003;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
Addresses issue #63.  The z-index of v-app-bar in vuetify 3 is 1004, so I went with the next lowest value. However, it's entirely possible there are other considerations here I'm missing, and I'd be happy to hear about them if that's the case.