### PR TITLE
Comment placed inside the template

### DIFF
--- a/src/components/TableLiteTs.vue
+++ b/src/components/TableLiteTs.vue
@@ -1,5 +1,5 @@
-<!-- eslint-disable @typescript-eslint/no-explicit-any -->
 <template>
+<!-- eslint-disable @typescript-eslint/no-explicit-any -->
   <div class="vtl vtl-card">
     <div class="vtl-card-title" v-if="title">{{ title }}</div>
     <div class="vtl-card-body">
@@ -349,9 +349,8 @@
       </div>
     </div>
   </div>
-</template>
-
 <!-- eslint-disable @typescript-eslint/no-explicit-any -->
+</template>
 <script lang="ts">
 import {
   defineComponent,


### PR DESCRIPTION
The previous code was throwing error:

[error] [nitro] RollupError: Expression expected (Note that you need plugins to import files that are not JavaScript)
1: <!-- eslint-disable @typescript-eslint/no-explicit-any -->
   ^
2: <template>
3:   <div class="vtl vtl-card">
[error] Expression expected (Note that you need plugins to import files that are not JavaScript)
  at error (node_modules/rollup/dist/es/shared/parseAst.js:337:30)
  at nodeConverters (node_modules/rollup/dist/es/shared/parseAst.js:2084:9)
  at convertNode (node_modules/rollup/dist/es/shared/parseAst.js:969:12)
  at convertProgram (node_modules/rollup/dist/es/shared/parseAst.js:960:48)
  at parseAstAsync (node_modules/rollup/dist/es/shared/parseAst.js:2150:20)
  at async Module.tryParseAsync (node_modules/rollup/dist/es/shared/node-entry.js:13496:21)
  at async Module.setSource (node_modules/rollup/dist/es/shared/node-entry.js:13077:35)
  at async ModuleLoader.addModuleSource (node_modules/rollup/dist/es/shared/node-entry.js:17724:13) 
[error] Expression expected (Note that you need plugins to import files that are not JavaScript)
Error: Command "nuxt build" exited with 1