### PR TITLE
Typing emit functions

### DIFF
--- a/src/components/TableLiteTs.vue
+++ b/src/components/TableLiteTs.vue
@@ -394,14 +394,20 @@ interface column {
 
 export default defineComponent({
   name: "my-table",
-  emits: [
-    "return-checked-rows",
-    "do-search",
-    "is-finished",
-    "get-now-page",
-    "row-clicked",
-    "row-toggled",
-  ],
+  emits: {
+    // eslint-disable-next-line
+    "return-checked-rows": (_rows: any[]) => true,
+    // eslint-disable-next-line
+    "do-search": (_offset: number, _limit: number, _order: string, _sort: string) => true,
+    // eslint-disable-next-line
+    "is-finished": (_elements: HTMLCollectionOf<Element>) => true,
+    // eslint-disable-next-line
+    "get-now-page": (_pageNo: number) => true,
+    // eslint-disable-next-line
+    "row-clicked": (_row: any) => true,
+    // eslint-disable-next-line
+    "row-toggled": (_rows: any[], _isCollapsed: boolean) => true,
+  },
   props: {
     // 是否讀取中 (is data loading)
     isLoading: {


### PR DESCRIPTION
To better type the emit functions outside the components, a typing  workaround was added to the emits as the defineEmits cannot be used with the Options API. I had to disable eslint on those definitions to prevent throwing warnings for unused variables.

New snippet with the event type:
![image](https://github.com/linmasahiro/vue3-table-lite/assets/38531751/361e1f25-07ab-4840-b569-5279dcb9951c)

Let me know if there is something to change.
