### PR TITLE
Add index and child-index in is-slot-mode=true for efficient table operations.

### DIFF
--- a/src/components/TableLite.vue
+++ b/src/components/TableLite.vue
@@ -143,7 +143,7 @@
                       <div v-if="col.display" v-html="col.display(row)"></div>
                       <div v-else>
                         <div v-if="setting.isSlotMode && slots[col.field]">
-                          <slot :name="col.field" :value="row"></slot>
+                          <slot :name="col.field" :index="i" :value="row"></slot>
                         </div>
                         <span v-else>{{ row[col.field] }}</span>
                       </div>
@@ -156,7 +156,7 @@
                 :set="(templateRows = groupingKey == '' ? [rows] : groupingRows)"
               >
                 <template
-                  v-for="(rows, groupingIndex) in templateRows"
+                  v-for="(rows, groupingIndex,index) in templateRows"
                   :key="groupingIndex"
                 >
                   <tr v-if="groupingKey != ''" class="vtl-tbody-tr vtl-group-tr">
@@ -231,7 +231,7 @@
                       <div v-if="col.display" v-html="col.display(row)"></div>
                       <div v-else>
                         <div v-if="setting.isSlotMode && slots[col.field]">
-                          <slot :name="col.field" :value="row"></slot>
+                          <slot :name="col.field" :index="index" :childIndex="i" :value="row"></slot>
                         </div>
                         <span v-else>{{ row[col.field] }}</span>
                       </div>

--- a/src/components/TableLiteTs.vue
+++ b/src/components/TableLiteTs.vue
@@ -143,7 +143,7 @@
                       <div v-if="col.display" v-html="col.display(row)"></div>
                       <div v-else>
                         <div v-if="setting.isSlotMode && slots[col.field]">
-                          <slot :name="col.field" :value="row"></slot>
+                          <slot :name="col.field" :index="i" :value="row"></slot>
                         </div>
                         <span v-else>{{ row[col.field] }}</span>
                       </div>
@@ -156,7 +156,7 @@
                 :set="(templateRows = groupingKey == '' ? [rows] : groupingRows)"
               >
                 <template
-                  v-for="(rows, groupingIndex) in templateRows"
+                  v-for="(rows, groupingIndex,index) in templateRows"
                   :key="groupingIndex"
                 >
                   <tr v-if="groupingKey != ''" class="vtl-tbody-tr vtl-group-tr">
@@ -227,7 +227,8 @@
                       <div v-if="col.display" v-html="col.display(row)"></div>
                       <div v-else>
                         <div v-if="setting.isSlotMode && slots[col.field]">
-                          <slot :name="col.field" :value="row"></slot>
+                          <!-- <slot :name="col.field" :index="i" :value="row"></slot> -->
+                          <slot :name="col.field" :index="index" :childIndex="i" :value="row"></slot>
                         </div>
                         <span v-else>{{ row[col.field] }}</span>
                       </div>

--- a/src/examples/VSlotMode.vue
+++ b/src/examples/VSlotMode.vue
@@ -1,7 +1,14 @@
 <template>
-  <table-lite :is-slot-mode="true" :is-loading="table.isLoading" :columns="table.columns" :rows="table.rows"
-    :total="table.totalRecordCount" :sortable="table.sortable" @do-search="doSearch"
-    @is-finished="table.isLoading = false">
+  <table-lite
+    :is-slot-mode="true"
+    :is-loading="table.isLoading"
+    :columns="table.columns"
+    :rows="table.rows"
+    :total="table.totalRecordCount"
+    :sortable="table.sortable"
+    @do-search="doSearch"
+    @is-finished="table.isLoading = false"
+  >
     <template v-slot:name="data">
       <Test>
         {{ data.childIndex }}  <!-- // show the index of table  -->
@@ -11,10 +18,12 @@
     </template>
   </table-lite>
 </template>
+
 <script>
 import { defineComponent, reactive } from "vue";
 import TableLite from "../components/TableLite.vue";
 import Test from "../components/Test.vue";
+
 // Fake Data for 'asc' sortable
 const sampleData1 = (offst, limit) => {
   offst = offst + 1;
@@ -28,6 +37,7 @@ const sampleData1 = (offst, limit) => {
   }
   return data;
 };
+
 // Fake Data for 'desc' sortable
 const sampleData2 = (offst, limit) => {
   let data = [];
@@ -40,6 +50,7 @@ const sampleData2 = (offst, limit) => {
   }
   return data;
 };
+
 export default defineComponent({
   name: "App",
   components: { TableLite, Test },
@@ -75,6 +86,7 @@ export default defineComponent({
         sort: "asc",
       },
     });
+
     /**
      * Search Event
      */
@@ -95,8 +107,10 @@ export default defineComponent({
         table.sortable.sort = sort;
       }, 600);
     };
+
     // First get data
     doSearch(0, 10, "id", "asc");
+
     return {
       table,
       doSearch,

--- a/src/examples/VSlotMode.vue
+++ b/src/examples/VSlotMode.vue
@@ -1,27 +1,20 @@
 <template>
-  <table-lite
-    :is-slot-mode="true"
-    :is-loading="table.isLoading"
-    :columns="table.columns"
-    :rows="table.rows"
-    :total="table.totalRecordCount"
-    :sortable="table.sortable"
-    @do-search="doSearch"
-    @is-finished="table.isLoading = false"
-  >
+  <table-lite :is-slot-mode="true" :is-loading="table.isLoading" :columns="table.columns" :rows="table.rows"
+    :total="table.totalRecordCount" :sortable="table.sortable" @do-search="doSearch"
+    @is-finished="table.isLoading = false">
     <template v-slot:name="data">
       <Test>
+        {{ data.childIndex }}  <!-- // show the index of table  -->
+        <!-- {{ data?.index }} // only working in grouping  -->
         {{ data.value.name }}
       </Test>
     </template>
   </table-lite>
 </template>
-
 <script>
 import { defineComponent, reactive } from "vue";
 import TableLite from "../components/TableLite.vue";
 import Test from "../components/Test.vue";
-
 // Fake Data for 'asc' sortable
 const sampleData1 = (offst, limit) => {
   offst = offst + 1;
@@ -35,7 +28,6 @@ const sampleData1 = (offst, limit) => {
   }
   return data;
 };
-
 // Fake Data for 'desc' sortable
 const sampleData2 = (offst, limit) => {
   let data = [];
@@ -48,7 +40,6 @@ const sampleData2 = (offst, limit) => {
   }
   return data;
 };
-
 export default defineComponent({
   name: "App",
   components: { TableLite, Test },
@@ -84,7 +75,6 @@ export default defineComponent({
         sort: "asc",
       },
     });
-
     /**
      * Search Event
      */
@@ -105,10 +95,8 @@ export default defineComponent({
         table.sortable.sort = sort;
       }, 600);
     };
-
     // First get data
     doSearch(0, 10, "id", "asc");
-
     return {
       table,
       doSearch,


### PR DESCRIPTION
### Why do we need `index` and `child-index` in `is-slot-mode=true`?

Using `index` for groups and `child-index` for normal rows simplifies operations like **delete** and **update** in dynamic tables. These indices allow direct access to rows or groups without needing to search for their position, improving efficiency.

### Examples:

1. **Deleting a Row:**
   - You can directly remove a row using the `index` or `child-index`:
     ```javascript
     // Using index to delete
     data.splice(index, 1);
     ```

2. **Updating a Child Row in a Group:**
   - To update a specific child row in a grouped table:
     ```javascript
     // Using parent index and child index
     groupedData[parentIndex].children[childIndex].value = "Updated Value";
     ```

By leveraging `index` and `child-index`, you avoid complex searches (`findIndex`) and streamline table operations.
